### PR TITLE
Ensure long output does not exceed API limits

### DIFF
--- a/hipsaint/card.py
+++ b/hipsaint/card.py
@@ -16,6 +16,16 @@ class Card(object):
             self.service, self.hostalias, self.timestamp, self.ntype, self.hostaddress, self.state, self.hostoutput = [
                 inp.strip() for inp in self.inputs.split('|')]
 
+        # Ensure len of message body does not exceed limits
+        # https://www.hipchat.com/docs/apiv2/method/send_room_notification
+        msg_body_len = len(self.hostoutput)
+
+        if msg_body_len >= 500:
+            logging.warning('Host/Service ouput exceeds maximum allowed by V2 API: 500 ' \
+                + 'characters. Requested: ' + str(msg_body_len) \
+                + '. Truncating output to 500 total characters')
+            self.hostoutput = self.hostoutput[:487] + ' <truncated>"
+            
     def get_attributes(self):
         """
         More about Card attributes:


### PR DESCRIPTION
With some of our simple checks, long output cause an issue:

```
Traceback (most recent call last):
  File "/home/icinga/.local/share/virtualenvs/icinga-plugins--BT7bI7t/bin/hipsaint", line 11, in <module>
    load_entry_point('hipsaint', 'console_scripts', 'hipsaint')()
  File "/opt/icinga-plugins/hipsaint-test/hipsaint/bin/commands.py", line 85, in main
    msg.deliver_payload()
  File "/opt/icinga-plugins/hipsaint-test/hipsaint/messages.py", line 102, in deliver_payload_v2
    raw_response = urlopen(request)
  File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python2.7/urllib2.py", line 437, in open
    response = meth(req, response)
  File "/usr/lib64/python2.7/urllib2.py", line 550, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib64/python2.7/urllib2.py", line 475, in error
    return self._call_chain(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/usr/lib64/python2.7/urllib2.py", line 558, in http_error_default
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
urllib2.HTTPError: HTTP Error 400: Bad Request
```

This is due to limitations set by the hipchat API. This proposed change detects and truncates long output for the card. It does not affect what is seen in an email or in Icingaweb2.